### PR TITLE
TacRP Improvements

### DIFF
--- a/lua/holohud2/add-ons/tacrp.lua
+++ b/lua/holohud2/add-ons/tacrp.lua
@@ -22,7 +22,7 @@ HOLOHUD2.hook.Add( "GetWeaponFiremode", "tacrp", function( weapon )
 
     if weapon:GetSafe() then return FIREMODE_SAFE end
 
-    if not weapon.Firemodes or #weapon.Firemodes <= 0 then return end
+    if weapon:GetFiremodeAmount() <= 0 then return end
 
     local firemode = weapon:GetCurrentFiremode()
 
@@ -41,7 +41,186 @@ HOLOHUD2.hook.Add( "GetWeaponFiremode", "tacrp", function( weapon )
     elseif firemode < 0 then
 
         return FIREMODE_3BURST
-        
+
     end
 
 end)
+
+---
+--- Grenade ammo icons
+---
+
+HOLOHUD2.ammo.Register(
+    "ti_flashbang",
+    surface.GetTextureID( "tacrp/grenades/flashbang" ),
+    32, 32,
+    32, 32,
+    {
+        icon_scale = 1,
+        tray_angle_x = 0,
+        tray_margin_x = 0.75,
+        tray_angle_y = -90,
+        tray_margin_y = 0.75
+    }
+)
+
+HOLOHUD2.ammo.Register(
+    "ti_smoke",
+    surface.GetTextureID( "tacrp/grenades/smoke" ),
+    32, 32,
+    32, 32,
+    {
+        icon_scale = 1,
+        tray_angle_x = 0,
+        tray_margin_x = 0.75,
+        tray_angle_y = -90,
+        tray_margin_y = 0.75
+    }
+)
+
+HOLOHUD2.ammo.Register(
+    "ti_gas",
+    surface.GetTextureID( "tacrp/grenades/gas" ),
+    32, 32,
+    32, 32,
+    {
+        icon_scale = 1,
+        tray_angle_x = 0,
+        tray_margin_x = 0.75,
+        tray_angle_y = -90,
+        tray_margin_y = 0.75
+    }
+)
+
+HOLOHUD2.ammo.Register(
+    "ti_thermite",
+    surface.GetTextureID( "tacrp/grenades/thermite" ),
+    32, 32,
+    32, 32,
+    {
+        icon_scale = 1,
+        tray_angle_x = 0,
+        tray_margin_x = 0.75,
+        tray_angle_y = -90,
+        tray_margin_y = 0.75
+    }
+)
+
+HOLOHUD2.ammo.Register(
+    "ti_c4",
+    surface.GetTextureID( "tacrp/grenades/c4" ),
+    32, 32,
+    32, 32,
+    {
+        icon_scale = 1,
+        tray_angle_x = 0,
+        tray_margin_x = 0.75,
+        tray_angle_y = -90,
+        tray_margin_y = 0.75
+    }
+)
+
+HOLOHUD2.ammo.Register(
+    "ti_nuke",
+    surface.GetTextureID( "tacrp/grenades/nuke" ),
+    32, 32,
+    32, 32,
+    {
+        icon_scale = 1,
+        tray_angle_x = 0,
+        tray_margin_x = 0.75,
+        tray_angle_y = -90,
+        tray_margin_y = 0.75
+    }
+)
+
+HOLOHUD2.ammo.Register(
+    "ti_charge",
+    surface.GetTextureID( "tacrp/grenades/breach" ),
+    32, 32,
+    32, 32,
+    {
+        icon_scale = 1,
+        tray_angle_x = 0,
+        tray_margin_x = 0.75,
+        tray_angle_y = -90,
+        tray_margin_y = 0.75
+    }
+)
+
+HOLOHUD2.ammo.Register(
+    "ti_heal",
+    surface.GetTextureID( "tacrp/grenades/heal" ),
+    32, 32,
+    32, 32,
+    {
+        icon_scale = 1,
+        tray_angle_x = 0,
+        tray_margin_x = 0.75,
+        tray_angle_y = -90,
+        tray_margin_y = 0.75
+    }
+)
+
+---
+--- Expanded ammo type icons
+---
+
+HOLOHUD2.ammo.Register(
+    "ti_pistol_light",
+    surface.GetTextureID( "holohud2/ammo/pistol" ),
+    32, 32,
+    27, 10,
+    {
+        tray_scale_x = .85,
+        tray_margin_x = .7,
+        tray_margin_y = .7
+    }
+)
+
+HOLOHUD2.ammo.Register(
+    "ti_pistol_heavy",
+    surface.GetTextureID( "holohud2/ammo/pistol" ),
+    32, 32,
+    27, 10,
+    {
+        tray_scale_x = .85,
+        tray_margin_x = .7,
+        tray_margin_y = .7
+    }
+)
+
+HOLOHUD2.ammo.Register(
+    "ti_pdw",
+    surface.GetTextureID( "holohud2/ammo/smg1" ),
+    64, 32,
+    44, 13,
+    {
+        tray_scale_x = .9,
+        tray_margin_x = .5,
+        tray_margin_y = .5
+    }
+)
+
+HOLOHUD2.ammo.Register(
+    "ti_rifle",
+    surface.GetTextureID( "holohud2/ammo/ar2" ),
+    64, 32,
+    50, 11,
+    {
+        tray_margin_x = .5,
+        tray_margin_y = .5
+    }
+)
+
+HOLOHUD2.ammo.Register(
+    "ti_sniper",
+    surface.GetTextureID( "holohud2/ammo/357" ),
+    64, 32,
+    36, 13,
+    {
+        tray_scale_x = .9,
+        tray_margin_x = .6,
+        tray_margin_y = .6
+    }
+)

--- a/lua/holohud2/modules/util.lua
+++ b/lua/holohud2/modules/util.lua
@@ -359,9 +359,9 @@ hook.Add( "PreDrawHUD", "holohud2_util", function()
             
             end
 
-            primary = ( ammo.PrimaryClip or ammo.PrimaryAmmo ) and 1 or 0
+            primary = weapon:GetPrimaryAmmoType()
+            secondary = weapon:GetSecondaryAmmoType()
             ammo2, max_ammo2 = ammo.SecondaryAmmo or 0, 1
-            secondary = ammo.SecondaryAmmo and 1 or 0
 
             return
 


### PR DESCRIPTION
- Fix firemode display to consider SWEP.Firemode as well as SWEP.Firemodes
- Fix ammo type not being set correctly when CustomAmmoDisplay exists
- Add grenade and expanded ammo type icons