### PR TITLE
Small ECG fix

### DIFF
--- a/lua/holohud2/components/ecg.lua
+++ b/lua/holohud2/components/ecg.lua
@@ -81,7 +81,7 @@ end
 function COMPONENT:Add( pos )
 
     if #self._shape <= 0 then return end
-    if #self._shape >= 128 then
+    if #self._cache >= 128 then
         
         table.remove( self._cache, 1 )
 


### PR DESCRIPTION
Been sitting on it for months now. Just a very simple fix for this issue: https://github.com/DyaMetR/holohud2/issues/8#issuecomment-3476850645

As mentioned in the bug report, when the line is `_shape` is still overflows and crashes the game.
But when using `_cache` it works as expected.